### PR TITLE
 Enhancements to localized_country_select_tasks.rake

### DIFF
--- a/lib/tasks/localized_country_select_tasks.rake
+++ b/lib/tasks/localized_country_select_tasks.rake
@@ -20,7 +20,7 @@ require 'open-uri'
 # 
 # The code is deliberately procedural and simple, so it's easily
 # understandable by beginners as an introduction to Rake tasks power.
-# See http://github.com/joshmh/cldr/tree/master/converter.rb for much more robust solution
+# See https://github.com/svenfuchs/ruby-cldr for much more robust solution
 
 namespace :import do
 


### PR DESCRIPTION
1. Support .yml as output format (default is Ruby as per existing behavior) via FORMAT parameter.
2. Auto-convert user locale to Unicode.org CLDR acceptable code. This magic can be overriden by WEB_LOCALE parameter.
3. Output file name will be "countries.<locale>.<format>" in keeping with conventions of other ruby/rails i18n libraries
