### PR TITLE
Updated example in README.rdoc

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -50,7 +50,7 @@ will become:
 
 Show only country codes:
 
-   <%= localized_country_select(:user, :country, [], {:include_blank => 'Please choose...', :description => :abbreviated)}
+   <%= localized_country_select(:user, :country, [], {:include_blank => 'Please choose...', :description => :abbreviated})
 
 will become:
 


### PR DESCRIPTION
Fixed a small error in the examples on the README.rdoc. The ')' and '}' needed to be switched around.
