### PR TITLE
Option to exclude countries

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -50,7 +50,7 @@ will become:
 
 Show only country codes:
 
-   <%= localized_country_select(:user, :country, [], {:include_blank => 'Please choose...', :description => :abbreviated})
+   <%= localized_country_select(:user, :country, [], {:include_blank => 'Please choose...', :description => :abbreviated}) %>
 
 will become:
 
@@ -64,6 +64,11 @@ will become:
 
 
 for the <tt>en</tt> locale.
+
+
+You can exclude countries by code using the exclude option (a single code or an array of country codes):
+
+   localized_country_select(:user, :country, [], {:exclude => [:ZZ, :US]})
 
 
 == Formtastic and SimpleForm

--- a/lib/localized_country_select.rb
+++ b/lib/localized_country_select.rb
@@ -24,13 +24,13 @@ module LocalizedCountrySelect
     # Returns array with codes and localized country names (according to <tt>I18n.locale</tt>)
     # for <tt><option></tt> tags
     def localized_countries_array(options={})
+      exclude = Array(options[:exclude]).map {|code| code.to_s.upcase }
+
       if(options[:description]==:abbreviated)
-        I18n.translate(:countries).map { |key, value| [key.to_s.upcase] }.
-          sort_by { |country| country.first.parameterize }
+        I18n.translate(:countries).map { |key, value| [key.to_s.upcase] if !exclude.include?(key.to_s.upcase) }
       else
-        I18n.translate(:countries).map { |key, value| [value, key.to_s.upcase] }.
-          sort_by { |country| country.first.parameterize }
-      end
+        I18n.translate(:countries).map { |key, value| [value, key.to_s.upcase] if !exclude.include?(key.to_s.upcase) }
+      end.compact.sort_by { |country| country.first.parameterize }
     end
     # Return array with codes and localized country names for array of country codes passed as argument
     # == Example

--- a/test/localized_country_select_test.rb
+++ b/test/localized_country_select_test.rb
@@ -68,6 +68,18 @@ class LocalizedCountrySelectTest < Test::Unit::TestCase
     assert_equal 'Španělsko', I18n.t('ES', :scope => 'countries')
   end
 
+  def test_excludes_countries
+    assert_nothing_raised { LocalizedCountrySelect::localized_countries_array(:exclude => :ZZ) }
+    
+    assert_block do
+      not LocalizedCountrySelect::localized_countries_array(:exclude => :ZZ).any? {|country| country.last == "ZZ"}
+    end
+
+    assert_block do
+      not LocalizedCountrySelect::localized_countries_array(:exclude => [:ZZ, :US]).any? {|country| country.last == "ZZ" or country.last == "US"}
+    end
+  end
+
   def test_localized_countries_array_returns_correctly
     assert_nothing_raised { LocalizedCountrySelect::localized_countries_array() }
     # puts LocalizedCountrySelect::localized_countries_array.inspect


### PR DESCRIPTION
Add an option to exclude countries with the :exclude option.

For example, I don't want the ZZ => "Unknown" country in my list of select options, though I still want a translation for the country code.
