### PR TITLE
Update gemspec to not require hpricot

### DIFF
--- a/localized_country_select.gemspec
+++ b/localized_country_select.gemspec
@@ -16,6 +16,5 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = LocalizedCountrySelect::VERSION
   gem.add_dependency "actionpack", ">= 3.0"
-  gem.add_dependency "hpricot"
   gem.add_development_dependency "rspec", ">= 2.0.0"
 end


### PR DESCRIPTION
The dependency on hpricot requires to bundle it even for production environments just to make the rake task work.

This is not desired, because in production the locales will not be changed.

It's better to make it a soft dependency, as already done in the rake task, which barks when the hpricot gem is missing.
