### PR TITLE
Multiple xml parsers support

### DIFF
--- a/localized_country_select.gemspec
+++ b/localized_country_select.gemspec
@@ -16,6 +16,5 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = LocalizedCountrySelect::VERSION
   gem.add_dependency "actionpack", ">= 3.0"
-  gem.add_dependency "hpricot"
   gem.add_development_dependency "rspec", ">= 2.0.0"
 end


### PR DESCRIPTION
- xml parser is detected automatically
- available parsers are nokogiri, hpricot and libxml-ruby
- using one of parsser can be forced with PARSER env variable
- remove hpricot dependency

This fixes issues #19 and #18.
