### PR TITLE
Fix import rake task

### DIFF
--- a/lib/tasks/localized_country_select_tasks.rake
+++ b/lib/tasks/localized_country_select_tasks.rake
@@ -78,7 +78,7 @@ namespace :import do
   countries:
 HEAD
       countries.each do |country|
-        output << "    #{country[:code]}: \"#{country[:name]}\"\n"
+        output << "    \"#{country[:code]}\": \"#{country[:name]}\"\n"
       end
 
     else # rb format
@@ -136,10 +136,10 @@ TAIL
         document.search("//tr").inject({}) do |hash, row|
           n = row.search("td[@class='n']")
           g = row.search("td")
-          if n.inner_html =~ /NamesTerritories/ && g.count >= 7 && g[4].inner_html =~ /^[A-Z]{2}/
+          if n.inner_html =~ /NamesTerritories/ && g.count >= 6 && g[4].inner_html =~ /^[A-Z]{2}/
             code = g[4].inner_text
             code = code[-code.size, 2].to_sym
-            name = row.search("td[@class='v']").inner_text
+            name = row.search("td[@class='v']:not([@title])").inner_text
 
             hash[code] = {:code => code, :name => name.to_s}
           end
@@ -163,10 +163,10 @@ TAIL
         document.find("//tr").inject({}) do |hash, row|
           n = row.find("td[@class='n']")
           g = row.find("td")
-          if n.map(&:content).join =~ /NamesTerritories/ && g.count >= 7 && g[4].inner_xml =~ /^[A-Z]{2}/
+          if n.map(&:content).join =~ /NamesTerritories/ && g.count >= 6 && g[4].inner_xml =~ /^[A-Z]{2}/
             code = g[4].content
             code = code[-code.size, 2].to_sym
-            name = row.find("td[@class='v']").map(&:content).join
+            name = row.find("td[@class='v' and not(@title)]").map(&:content).join
 
             hash[code] ||= {:code => code, :name => name.to_s}
           end


### PR DESCRIPTION
- Reduce number of columns (fixes en import)
- Skip sublocales (fixes double names like SimbabweZimbabwe)
- Quote YAML keys (fixes NO key being interpreted as false)

Import task tested with current versions of nokogiri, hpricot and libxml-ruby.
