### PR TITLE
Also list priority countries in their normal place alphabetically

### DIFF
--- a/lib/localized_country_select.rb
+++ b/lib/localized_country_select.rb
@@ -80,10 +80,8 @@ module ActionView
         if priority_countries
           country_options += options_for_select(LocalizedCountrySelect::priority_countries_array(priority_countries, options), selected)
           country_options += "<option value=\"\" disabled=\"disabled\">-------------</option>\n".html_safe
-          return country_options + options_for_select(LocalizedCountrySelect::localized_countries_array(options) - LocalizedCountrySelect::priority_countries_array(priority_countries, options), selected)
-        else
-          return country_options + options_for_select(LocalizedCountrySelect::localized_countries_array(options), selected)
         end
+        return country_options + options_for_select(LocalizedCountrySelect::localized_countries_array(options), selected)
       end
       alias_method :country_options_for_select, :localized_country_options_for_select
 


### PR DESCRIPTION
Having priority countries at the top is good, but if the dropdown is initialized with a different default, and the user wants to switch to one of those priority countries, they may not think to look at the top of the list.

This change makes it so priority countries are also listed in their normal alphabetical spot in addition to being at the top of the list.